### PR TITLE
add support for valves and remote

### DIFF
--- a/custom_components/ducobox-connectivity-board/sensor.py
+++ b/custom_components/ducobox-connectivity-board/sensor.py
@@ -334,6 +334,275 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             node_type='BSRH',
         ),
     ],
+    'VLVRH': [
+        DucoboxNodeSensorEntityDescription(
+            key='State',
+            name='Ventilation State',
+            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            sensor_key='State',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateRemain',
+            name='Time State Remaining',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            sensor_key='TimeStateRemain',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateEnd',
+            name='Time State End',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            sensor_key='TimeStateEnd',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Mode',
+            name='Ventilation Mode',
+            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            sensor_key='Mode',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='FlowLvlTgt',
+            name='Flow Level Target',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            sensor_key='FlowLvlTgt',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='IaqRh',
+            name='Humidity Air Quality',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('IaqRh')
+            ),
+            sensor_key='IaqRh',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Rh',
+            name='Humidity',
+            native_unit_of_measurement=PERCENTAGE,
+            device_class=SensorDeviceClass.HUMIDITY,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('Rh')
+            ),
+            sensor_key='Rh',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Temp',
+            name='Temperature',
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            value_fn=lambda node: _process_node_temperature(
+                node.get('Sensor', {}).get('data', {}).get('Temp')
+            ),
+            sensor_key='Temp',
+            node_type='VLVRH',
+        ),
+    ],
+    'VLVCO2': [
+        DucoboxNodeSensorEntityDescription(
+            key='State',
+            name='Ventilation State',
+            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            sensor_key='State',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateRemain',
+            name='Time State Remaining',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            sensor_key='TimeStateRemain',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateEnd',
+            name='Time State End',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            sensor_key='TimeStateEnd',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Mode',
+            name='Ventilation Mode',
+            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            sensor_key='Mode',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='FlowLvlTgt',
+            name='Flow Level Target',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            sensor_key='FlowLvlTgt',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Co2',
+            name='CO₂',
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.CO2,
+            value_fn=lambda node: _process_node_co2(
+                node.get('Sensor', {}).get('data', {}).get('Co2')
+            ),
+            sensor_key='Co2',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='IaqCo2',
+            name='CO₂ Air Quality',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('IaqCo2')
+            ),
+            sensor_key='IaqCo2',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Temp',
+            name='Temperature',
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            value_fn=lambda node: _process_node_temperature(
+                node.get('Sensor', {}).get('data', {}).get('Temp')
+            ),
+            sensor_key='Temp',
+            node_type='VLVCO2',
+        ),
+    ],
+    'VLVCO2RH': [
+        DucoboxNodeSensorEntityDescription(
+            key='State',
+            name='Ventilation State',
+            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            sensor_key='State',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateRemain',
+            name='Time State Remaining',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            sensor_key='TimeStateRemain',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateEnd',
+            name='Time State End',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            sensor_key='TimeStateEnd',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Mode',
+            name='Ventilation Mode',
+            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            sensor_key='Mode',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='FlowLvlTgt',
+            name='Flow Level Target',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            sensor_key='FlowLvlTgt',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Co2',
+            name='CO₂',
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.CO2,
+            value_fn=lambda node: _process_node_co2(
+                node.get('Sensor', {}).get('data', {}).get('Co2')
+            ),
+            sensor_key='Co2',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='IaqCo2',
+            name='CO₂ Air Quality',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('IaqCo2')
+            ),
+            sensor_key='IaqCo2',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Rh',
+            name='Humidity',
+            native_unit_of_measurement=PERCENTAGE,
+            device_class=SensorDeviceClass.HUMIDITY,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('Rh')
+            ),
+            sensor_key='Rh',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='IaqRh',
+            name='Humidity Air Quality',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('IaqRh')
+            ),
+            sensor_key='IaqRh',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Temp',
+            name='Temperature',
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            value_fn=lambda node: _process_node_temperature(
+                node.get('Sensor', {}).get('data', {}).get('Temp')
+            ),
+            sensor_key='Temp',
+            node_type='VLVCO2RH',
+        ),
+    ],
+    'UCBAT': [
+        DucoboxNodeSensorEntityDescription(
+            key='State',
+            name='Ventilation State',
+            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            sensor_key='State',
+            node_type='UCBAT',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateRemain',
+            name='Time State Remaining',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            sensor_key='TimeStateRemain',
+            node_type='UCBAT',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateEnd',
+            name='Time State End',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            sensor_key='TimeStateEnd',
+            node_type='UCBAT',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Mode',
+            name='Ventilation Mode',
+            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            sensor_key='Mode',
+            node_type='UCBAT',
+        ),
+    ],
     # Add other node types and their sensors if needed
 }
 


### PR DESCRIPTION
Hi,

Thanks for your work on the Ducobox HACS integration and ducopy.

I have a Ducobox Focus with humidity and/or CO2 controlled valves, and a battery remote. Added them to the integration (works in my setup). Added VLVRH (Humidity control valve), VLVCO2 (CO2 control valve) & VLVCO2RH (CO2/RH control valve), and UCBAT (Remote control RF/BAT).

Would love for these types to be integrated in the original repo.

<img width="1149" alt="Screenshot 2025-01-11 at 14 04 12" src="https://github.com/user-attachments/assets/763307b5-0139-40f5-b9e5-615add17a4d7" />
