### PR TITLE
Refactor of PR11

### DIFF
--- a/custom_components/ducobox-connectivity-board/sensor.py
+++ b/custom_components/ducobox-connectivity-board/sensor.py
@@ -338,7 +338,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
         DucoboxNodeSensorEntityDescription(
             key='State',
             name='Ventilation State',
-            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'State'),
             sensor_key='State',
             node_type='VLVRH',
         ),
@@ -346,7 +346,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='TimeStateRemain',
             name='Time State Remaining',
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'TimeStateRemain'),
             sensor_key='TimeStateRemain',
             node_type='VLVRH',
         ),
@@ -354,14 +354,14 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='TimeStateEnd',
             name='Time State End',
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'TimeStateEnd'),
             sensor_key='TimeStateEnd',
             node_type='VLVRH',
         ),
         DucoboxNodeSensorEntityDescription(
             key='Mode',
             name='Ventilation Mode',
-            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'Mode'),
             sensor_key='Mode',
             node_type='VLVRH',
         ),
@@ -369,7 +369,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='FlowLvlTgt',
             name='Flow Level Target',
             native_unit_of_measurement=PERCENTAGE,
-            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'FlowLvlTgt'),
             sensor_key='FlowLvlTgt',
             node_type='VLVRH',
         ),
@@ -378,18 +378,18 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             name='Humidity Air Quality',
             native_unit_of_measurement=PERCENTAGE,
             value_fn=lambda node: _process_node_iaq(
-                node.get('Sensor', {}).get('data', {}).get('IaqRh')
+                safe_get(node, 'Sensor', 'data', 'IaqRh')
             ),
             sensor_key='IaqRh',
             node_type='VLVRH',
         ),
         DucoboxNodeSensorEntityDescription(
             key='Rh',
-            name='Humidity',
+            name='Relative Humidity',
             native_unit_of_measurement=PERCENTAGE,
             device_class=SensorDeviceClass.HUMIDITY,
             value_fn=lambda node: _process_node_iaq(
-                node.get('Sensor', {}).get('data', {}).get('Rh')
+                safe_get(node, 'Sensor', 'data', 'Rh')
             ),
             sensor_key='Rh',
             node_type='VLVRH',
@@ -400,7 +400,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
             value_fn=lambda node: _process_node_temperature(
-                node.get('Sensor', {}).get('data', {}).get('Temp')
+                safe_get(node, 'Sensor', 'data', 'Temp')
             ),
             sensor_key='Temp',
             node_type='VLVRH',
@@ -410,7 +410,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
         DucoboxNodeSensorEntityDescription(
             key='State',
             name='Ventilation State',
-            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'State'),
             sensor_key='State',
             node_type='VLVCO2',
         ),
@@ -418,7 +418,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='TimeStateRemain',
             name='Time State Remaining',
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'TimeStateRemain'),
             sensor_key='TimeStateRemain',
             node_type='VLVCO2',
         ),
@@ -426,14 +426,14 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='TimeStateEnd',
             name='Time State End',
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'TimeStateEnd'),
             sensor_key='TimeStateEnd',
             node_type='VLVCO2',
         ),
         DucoboxNodeSensorEntityDescription(
             key='Mode',
             name='Ventilation Mode',
-            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'Mode'),
             sensor_key='Mode',
             node_type='VLVCO2',
         ),
@@ -441,7 +441,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='FlowLvlTgt',
             name='Flow Level Target',
             native_unit_of_measurement=PERCENTAGE,
-            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'FlowLvlTgt'),
             sensor_key='FlowLvlTgt',
             node_type='VLVCO2',
         ),
@@ -451,7 +451,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
             device_class=SensorDeviceClass.CO2,
             value_fn=lambda node: _process_node_co2(
-                node.get('Sensor', {}).get('data', {}).get('Co2')
+                safe_get(node, 'Sensor', 'data', 'Co2')
             ),
             sensor_key='Co2',
             node_type='VLVCO2',
@@ -461,7 +461,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             name='CO₂ Air Quality',
             native_unit_of_measurement=PERCENTAGE,
             value_fn=lambda node: _process_node_iaq(
-                node.get('Sensor', {}).get('data', {}).get('IaqCo2')
+                safe_get(node, 'Sensor', 'data', 'IaqCo2')
             ),
             sensor_key='IaqCo2',
             node_type='VLVCO2',
@@ -472,7 +472,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
             value_fn=lambda node: _process_node_temperature(
-                node.get('Sensor', {}).get('data', {}).get('Temp')
+                safe_get(node, 'Sensor', 'data', 'Temp')
             ),
             sensor_key='Temp',
             node_type='VLVCO2',
@@ -482,7 +482,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
         DucoboxNodeSensorEntityDescription(
             key='State',
             name='Ventilation State',
-            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'State'),
             sensor_key='State',
             node_type='VLVCO2RH',
         ),
@@ -490,7 +490,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='TimeStateRemain',
             name='Time State Remaining',
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'TimeStateRemain'),
             sensor_key='TimeStateRemain',
             node_type='VLVCO2RH',
         ),
@@ -498,14 +498,14 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='TimeStateEnd',
             name='Time State End',
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'TimeStateEnd'),
             sensor_key='TimeStateEnd',
             node_type='VLVCO2RH',
         ),
         DucoboxNodeSensorEntityDescription(
             key='Mode',
             name='Ventilation Mode',
-            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'Mode'),
             sensor_key='Mode',
             node_type='VLVCO2RH',
         ),
@@ -513,7 +513,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='FlowLvlTgt',
             name='Flow Level Target',
             native_unit_of_measurement=PERCENTAGE,
-            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'FlowLvlTgt'),
             sensor_key='FlowLvlTgt',
             node_type='VLVCO2RH',
         ),
@@ -523,7 +523,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
             device_class=SensorDeviceClass.CO2,
             value_fn=lambda node: _process_node_co2(
-                node.get('Sensor', {}).get('data', {}).get('Co2')
+                safe_get(node, 'Sensor', 'data', 'Co2')
             ),
             sensor_key='Co2',
             node_type='VLVCO2RH',
@@ -533,18 +533,18 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             name='CO₂ Air Quality',
             native_unit_of_measurement=PERCENTAGE,
             value_fn=lambda node: _process_node_iaq(
-                node.get('Sensor', {}).get('data', {}).get('IaqCo2')
+                safe_get(node, 'Sensor', 'data', 'IaqCo2')
             ),
             sensor_key='IaqCo2',
             node_type='VLVCO2RH',
         ),
         DucoboxNodeSensorEntityDescription(
             key='Rh',
-            name='Humidity',
+            name='Relative Humidity',
             native_unit_of_measurement=PERCENTAGE,
             device_class=SensorDeviceClass.HUMIDITY,
             value_fn=lambda node: _process_node_iaq(
-                node.get('Sensor', {}).get('data', {}).get('Rh')
+                safe_get(node, 'Sensor', 'data', 'Rh')
             ),
             sensor_key='Rh',
             node_type='VLVCO2RH',
@@ -554,7 +554,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             name='Humidity Air Quality',
             native_unit_of_measurement=PERCENTAGE,
             value_fn=lambda node: _process_node_iaq(
-                node.get('Sensor', {}).get('data', {}).get('IaqRh')
+                safe_get(node, 'Sensor', 'data', 'IaqRh')
             ),
             sensor_key='IaqRh',
             node_type='VLVCO2RH',
@@ -565,7 +565,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
             value_fn=lambda node: _process_node_temperature(
-                node.get('Sensor', {}).get('data', {}).get('Temp')
+                safe_get(node, 'Sensor', 'data', 'Temp')
             ),
             sensor_key='Temp',
             node_type='VLVCO2RH',
@@ -575,7 +575,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
         DucoboxNodeSensorEntityDescription(
             key='State',
             name='Ventilation State',
-            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'State'),
             sensor_key='State',
             node_type='UCBAT',
         ),
@@ -583,7 +583,7 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='TimeStateRemain',
             name='Time State Remaining',
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'TimeStateRemain'),
             sensor_key='TimeStateRemain',
             node_type='UCBAT',
         ),
@@ -591,14 +591,14 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             key='TimeStateEnd',
             name='Time State End',
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'TimeStateEnd'),
             sensor_key='TimeStateEnd',
             node_type='UCBAT',
         ),
         DucoboxNodeSensorEntityDescription(
             key='Mode',
             name='Ventilation Mode',
-            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            value_fn=lambda node: safe_get(node, 'Ventilation', 'Mode'),
             sensor_key='Mode',
             node_type='UCBAT',
         ),

--- a/custom_components/ducobox-connectivity-board/sensor.py
+++ b/custom_components/ducobox-connectivity-board/sensor.py
@@ -334,6 +334,275 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             node_type='BSRH',
         ),
     ],
+    'VLVRH': [
+        DucoboxNodeSensorEntityDescription(
+            key='State',
+            name='Ventilation State',
+            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            sensor_key='State',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateRemain',
+            name='Time State Remaining',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            sensor_key='TimeStateRemain',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateEnd',
+            name='Time State End',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            sensor_key='TimeStateEnd',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Mode',
+            name='Ventilation Mode',
+            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            sensor_key='Mode',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='FlowLvlTgt',
+            name='Flow Level Target',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            sensor_key='FlowLvlTgt',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='IaqRh',
+            name='Humidity Air Quality',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('IaqRh')
+            ),
+            sensor_key='IaqRh',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Rh',
+            name='Humidity',
+            native_unit_of_measurement=PERCENTAGE,
+            device_class=SensorDeviceClass.HUMIDITY,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('Rh')
+            ),
+            sensor_key='Rh',
+            node_type='VLVRH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Temp',
+            name='Temperature',
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            value_fn=lambda node: _process_node_temperature(
+                node.get('Sensor', {}).get('data', {}).get('Temp')
+            ),
+            sensor_key='Temp',
+            node_type='VLVRH',
+        ),
+    ],
+    'VLVCO2': [
+        DucoboxNodeSensorEntityDescription(
+            key='State',
+            name='Ventilation State',
+            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            sensor_key='State',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateRemain',
+            name='Time State Remaining',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            sensor_key='TimeStateRemain',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateEnd',
+            name='Time State End',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            sensor_key='TimeStateEnd',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Mode',
+            name='Ventilation Mode',
+            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            sensor_key='Mode',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='FlowLvlTgt',
+            name='Flow Level Target',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            sensor_key='FlowLvlTgt',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Co2',
+            name='CO₂',
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.CO2,
+            value_fn=lambda node: _process_node_co2(
+                node.get('Sensor', {}).get('data', {}).get('Co2')
+            ),
+            sensor_key='Co2',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='IaqCo2',
+            name='CO₂ Air Quality',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('IaqCo2')
+            ),
+            sensor_key='IaqCo2',
+            node_type='VLVCO2',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Temp',
+            name='Temperature',
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            value_fn=lambda node: _process_node_temperature(
+                node.get('Sensor', {}).get('data', {}).get('Temp')
+            ),
+            sensor_key='Temp',
+            node_type='VLVCO2',
+        ),
+    ],
+    'VLVCO2RH': [
+        DucoboxNodeSensorEntityDescription(
+            key='State',
+            name='Ventilation State',
+            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            sensor_key='State',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateRemain',
+            name='Time State Remaining',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            sensor_key='TimeStateRemain',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateEnd',
+            name='Time State End',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            sensor_key='TimeStateEnd',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Mode',
+            name='Ventilation Mode',
+            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            sensor_key='Mode',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='FlowLvlTgt',
+            name='Flow Level Target',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: node.get('Ventilation', {}).get('FlowLvlTgt'),
+            sensor_key='FlowLvlTgt',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Co2',
+            name='CO₂',
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.CO2,
+            value_fn=lambda node: _process_node_co2(
+                node.get('Sensor', {}).get('data', {}).get('Co2')
+            ),
+            sensor_key='Co2',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='IaqCo2',
+            name='CO₂ Air Quality',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('IaqCo2')
+            ),
+            sensor_key='IaqCo2',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Rh',
+            name='Humidity',
+            native_unit_of_measurement=PERCENTAGE,
+            device_class=SensorDeviceClass.HUMIDITY,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('Rh')
+            ),
+            sensor_key='Rh',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='IaqRh',
+            name='Humidity Air Quality',
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: _process_node_iaq(
+                node.get('Sensor', {}).get('data', {}).get('IaqRh')
+            ),
+            sensor_key='IaqRh',
+            node_type='VLVCO2RH',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Temp',
+            name='Temperature',
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            value_fn=lambda node: _process_node_temperature(
+                node.get('Sensor', {}).get('data', {}).get('Temp')
+            ),
+            sensor_key='Temp',
+            node_type='VLVCO2RH',
+        ),
+    ],
+    'UCBAT': [
+        DucoboxNodeSensorEntityDescription(
+            key='State',
+            name='Ventilation State',
+            value_fn=lambda node: node.get('Ventilation', {}).get('State'),
+            sensor_key='State',
+            node_type='UCBAT',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateRemain',
+            name='Time State Remaining',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateRemain'),
+            sensor_key='TimeStateRemain',
+            node_type='UCBAT',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='TimeStateEnd',
+            name='Time State End',
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value_fn=lambda node: node.get('Ventilation', {}).get('TimeStateEnd'),
+            sensor_key='TimeStateEnd',
+            node_type='UCBAT',
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key='Mode',
+            name='Ventilation Mode',
+            value_fn=lambda node: node.get('Ventilation', {}).get('Mode'),
+            sensor_key='Mode',
+            node_type='UCBAT',
+        ),
+    ],
     # Add other node types and their sensors if needed
 }
 


### PR DESCRIPTION
Refactor of PR #11 to use the more robust safe_get. This makes it less likely for the plug-in to crash when things inevitably change over time.

