### PR TITLE
use standard REVOLUTIONS_PER_MINUTE instead of custom RPM

### DIFF
--- a/custom_components/ducobox-connectivity-board/model/devices.py
+++ b/custom_components/ducobox-connectivity-board/model/devices.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     UnitOfTime,
     PERCENTAGE,
     CONCENTRATION_PARTS_PER_MILLION,
+    REVOLUTIONS_PER_MINUTE,
 )
 
 
@@ -96,9 +97,8 @@ SENSORS: tuple[DucoboxSensorEntityDescription, ...] = (
     DucoboxSensorEntityDescription(
         key="SpeedSup",
         name="Supply Fan Speed",
-        native_unit_of_measurement="RPM",
+        native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.SPEED,
         value_fn=lambda data: process_speed(
             safe_get(data, 'info', 'Ventilation', 'Fan', 'SpeedSup', 'Val')
         ),
@@ -106,9 +106,8 @@ SENSORS: tuple[DucoboxSensorEntityDescription, ...] = (
     DucoboxSensorEntityDescription(
         key="SpeedEha",
         name="Exhaust Fan Speed",
-        native_unit_of_measurement="RPM",
+        native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.SPEED,
         value_fn=lambda data: process_speed(
             safe_get(data, 'info', 'Ventilation', 'Fan', 'SpeedEha', 'Val')
         ),


### PR DESCRIPTION
Hi,

I kept getting messages in the logs that 'RPM' is not a valid unit for the device class 'speed'. This is used for the Supply Fan Speed & Exhaust Fan Speed. There is a standard REVOLUTIONS_PER_MINUTE (see [const.py](https://github.com/home-assistant/core/blob/dev/homeassistant/const.py). The device class 'speed' used for these entities gives errors, this should be 'none'.

This pull request fixes these issues.