### PR TITLE
Only add entities when they are actually available

### DIFF
--- a/custom_components/ducobox-connectivity-board/config_flow.py
+++ b/custom_components/ducobox-connectivity-board/config_flow.py
@@ -100,14 +100,11 @@ class DucoboxConnectivityBoardConfigFlow(config_entries.ConfigFlow, domain=DOMAI
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return DucoboxOptionsFlowHandler(config_entry)
+        return DucoboxOptionsFlowHandler()
 
 
 class DucoboxOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Ducobox Connectivity Board."""
-
-    def __init__(self, config_entry):
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage options."""

--- a/custom_components/ducobox-connectivity-board/model/coordinator.py
+++ b/custom_components/ducobox-connectivity-board/model/coordinator.py
@@ -65,11 +65,12 @@ class DucoboxCoordinator(DataUpdateCoordinator):
             data['info'] = duco_client.get_info()
             _LOGGER.debug(f"Data received from /info: {data}")
 
-            nodes_response = duco_client.get_nodes()
+            # Use raw_get to bypass Pydantic validation which may be too strict
+            nodes_response = duco_client.raw_get('/info/nodes')
             _LOGGER.debug(f"Data received from /info/nodes: {nodes_response}")
 
-            if nodes_response and hasattr(nodes_response, 'Nodes'):
-                data['nodes'] = [node.dict() for node in nodes_response.Nodes]
+            if nodes_response and 'Nodes' in nodes_response:
+                data['nodes'] = nodes_response['Nodes']
             else:
                 data['nodes'] = []
 

--- a/custom_components/ducobox-connectivity-board/model/utils.py
+++ b/custom_components/ducobox-connectivity-board/model/utils.py
@@ -7,6 +7,13 @@ def safe_get(data, *keys):
             return None
     return data
 
+
+def extract_val(data):
+    """Extract 'Val' from a dict if present, otherwise return the data as-is."""
+    if isinstance(data, dict) and 'Val' in data:
+        return data['Val']
+    return data
+
 # Node-specific processing functions
 def process_node_temperature(value):
     """Process node temperature values."""

--- a/custom_components/ducobox-connectivity-board/sensor.py
+++ b/custom_components/ducobox-connectivity-board/sensor.py
@@ -47,8 +47,13 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
 
-    # Add main Ducobox sensors
+    # Add main Ducobox sensors (only if data exists)
     for description in SENSORS:
+        # Check if sensor data exists
+        if description.data_path is not None:
+            if safe_get(coordinator.data, *description.data_path) is None:
+                continue  # Skip sensor if data path doesn't exist
+
         unique_id = f"{device_id}-{description.key}"
         entities.append(
             DucoboxSensorEntity(
@@ -77,9 +82,14 @@ async def async_setup_entry(
             via_device=(DOMAIN, device_id),
         )
 
-        # Get the sensors for this node type
+        # Get the sensors for this node type (only if data exists)
         node_sensors = NODE_SENSORS.get(node_type, [])
         for description in node_sensors:
+            # Check if sensor data exists in this node
+            if description.data_path is not None:
+                if safe_get(node, *description.data_path) is None:
+                    continue  # Skip sensor if data path doesn't exist
+
             unique_id = f"{node_device_id}-{description.key}"
             entities.append(
                 DucoboxNodeSensorEntity(


### PR DESCRIPTION
Certain devices have more or less sensors that they expose, but the integration would add entities for all regardless. 

This PR checks for the existence of sensor data before adding entities